### PR TITLE
Use first multipass reported VM IP in cluster.yml

### DIFF
--- a/multipass-rke.sh
+++ b/multipass-rke.sh
@@ -109,9 +109,9 @@ echo "ssh_key_path: ${SSH_PRIVKEYFILE}" >> "${NAME}-cluster.yml"
 echo "nodes:" >> "${NAME}-cluster.yml"
 
 if hash docker >/dev/null 2>&1; then
-    multipass list --format json | docker run -e NAME --rm -i $JQIMAGE --arg NAME "$NAME" -r '.list[] | select((.state | contains("Running")) and (.name | contains("rke-" + $NAME))) | "- address: " + .ipv4[] + "\n  user: ubuntu\n  role: [controlplane,worker,etcd]"' >> "${NAME}-cluster.yml"
+    multipass list --format json | docker run -e NAME --rm -i $JQIMAGE --arg NAME "$NAME" -r '.list[] | select((.state | contains("Running")) and (.name | contains("rke-" + $NAME))) | "- address: " + .ipv4[0] + "\n  user: ubuntu\n  role: [controlplane,worker,etcd]"' >> "${NAME}-cluster.yml"
 else
-    multipass list --format json | jq --arg NAME "$NAME" -r '.list[] | select((.state | contains("Running")) and (.name | contains("rke-" + $NAME))) | "- address: " + .ipv4[] + "\n  user: ubuntu\n  role: [controlplane,worker,etcd]"' >> "${NAME}-cluster.yml"
+    multipass list --format json | jq --arg NAME "$NAME" -r '.list[] | select((.state | contains("Running")) and (.name | contains("rke-" + $NAME))) | "- address: " + .ipv4[0] + "\n  user: ubuntu\n  role: [controlplane,worker,etcd]"' >> "${NAME}-cluster.yml"
 fi
 
 echo "RKE cluster configuration file is created at ${NAME}-cluster.yml"


### PR DESCRIPTION
After the multipass VMs have installed docker, multipass starts reporting two IP addresses per VM:
```
> multipass ls
Name                    State             IPv4             Image
rke-koipond-1           Running           10.93.66.190     Ubuntu 20.04 LTS
                                          172.17.0.1
rke-koipond-2           Running           10.93.66.216     Ubuntu 20.04 LTS
                                          172.17.0.1
rke-koipond-3           Running           10.93.66.28      Ubuntu 20.04 LTS
                                          172.17.0.1
```
This results in the generated `${NAME}-cluster.yml` file having two entries per VM.
```
ssh_key_path: /home/tahasi/workspace/k8s/koipond-cluster/koipond-id_rsa
nodes:
- address: 10.93.66.57
  user: ubuntu
  role: [controlplane,worker,etcd]
- address: 172.17.0.1
  user: ubuntu
  role: [controlplane,worker,etcd]
- address: 10.93.66.128
  user: ubuntu
  role: [controlplane,worker,etcd]
- address: 172.17.0.1
  user: ubuntu
  role: [controlplane,worker,etcd]
- address: 10.93.66.164
  user: ubuntu
  role: [controlplane,worker,etcd]
- address: 172.17.0.1
  user: ubuntu
  role: [controlplane,worker,etcd]
```

 The first entry per VM is the `ens4` device IP and the other is `docker0`.
```
> multipass shell rke-koipond-1
Welcome to Ubuntu 20.04.2 LTS (GNU/Linux 5.4.0-73-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Sun May 23 11:00:43 PDT 2021

  System load:  0.14              Processes:                121
  Usage of /:   19.9% of 9.52GB   Users logged in:          0
  Memory usage: 7%                IPv4 address for docker0: 172.17.0.1
  Swap usage:   0%                IPv4 address for ens4:    10.93.66.190
```